### PR TITLE
Highlight installed version, show concrete Latest tag, pin Beta to top of version selector

### DIFF
--- a/data/launcher/main.js
+++ b/data/launcher/main.js
@@ -3617,6 +3617,11 @@
       getExternal().getSelectedVersion();
     if (sv) {
       _selectedVersion = sv;
+
+      var initialLabel = "Latest (Auto-update)";
+      if (_selectedVersion === "beta") initialLabel = "Beta (Experimental)";
+      else if (_selectedVersion !== "latest") initialLabel = _selectedVersion;
+      selectVersion(_selectedVersion, initialLabel);
     }
   } catch (e) {}
 
@@ -3656,11 +3661,7 @@
           // After loading all versions, ensure UI reflects saved selection
           var label = "Latest (Auto-update)";
           if (_selectedVersion === "beta") label = "Beta (Experimental)";
-          else if (
-            _selectedVersion !== "latest" &&
-            _versionsData[_selectedVersion]
-          )
-            label = _selectedVersion;
+          else if (_selectedVersion !== "latest") label = _selectedVersion;
           selectVersion(_selectedVersion, label);
         } catch (e) {
           console.error("Error parsing releases:", e);

--- a/data/launcher/main.js
+++ b/data/launcher/main.js
@@ -30,7 +30,6 @@
   var versionOptions = document.getElementById("versionOptions");
   var _versionsData = {};
   var _selectedVersion = "latest";
-  var _currentRunningVersion = "";
   var _latestVersionTag = "";
 
   var workshopBrowseGrid = document.getElementById("workshopBrowseGrid");
@@ -302,7 +301,6 @@
     var ver =
       getExternal() && getExternal().getVersion && getExternal().getVersion();
     if (ver) {
-      _currentRunningVersion = "v" + ver;
       var vd = document.getElementById("versionDisplay");
       if (vd) vd.textContent = "v" + ver;
       var sv = document.getElementById("settingsVersion");
@@ -3577,10 +3575,7 @@
     var div = document.createElement("div");
     div.className = "version-selector-option";
     div.setAttribute("data-value", value);
-    div.textContent =
-      _currentRunningVersion && value === _currentRunningVersion
-        ? label + " (installed)"
-        : label;
+    div.textContent = label;
     div.onclick = function () {
       selectVersion(value, label);
     };
@@ -3687,7 +3682,11 @@
                   url: boiiiAsset.browser_download_url,
                   name: "boiii-" + tagName + ".exe",
                 };
-                addVersionOption(tagName, tagName);
+                // The newest release is already represented by the Latest
+                // entry, so skip adding it a second time as its own row.
+                if (tagName !== _latestVersionTag) {
+                  addVersionOption(tagName, tagName);
+                }
               }
             }
           }

--- a/data/launcher/main.js
+++ b/data/launcher/main.js
@@ -3537,6 +3537,14 @@
 
   loadFriendsList();
 
+  function versionTagFromStored(value) {
+    if (!value) return value;
+    var tag = value;
+    if (tag.indexOf("boiii-") === 0) tag = tag.substring("boiii-".length);
+    if (tag.slice(-4) === ".exe") tag = tag.slice(0, -4);
+    return tag;
+  }
+
   function selectVersion(value, label) {
     _selectedVersion = value;
     if (verDropText) verDropText.textContent = label;
@@ -3616,7 +3624,7 @@
       getExternal().getSelectedVersion &&
       getExternal().getSelectedVersion();
     if (sv) {
-      _selectedVersion = sv;
+      _selectedVersion = versionTagFromStored(sv);
 
       var initialLabel = "Latest (Auto-update)";
       if (_selectedVersion === "beta") initialLabel = "Beta (Experimental)";

--- a/data/launcher/main.js
+++ b/data/launcher/main.js
@@ -30,6 +30,8 @@
   var versionOptions = document.getElementById("versionOptions");
   var _versionsData = {};
   var _selectedVersion = "latest";
+  var _currentRunningVersion = "";
+  var _latestVersionTag = "";
 
   var workshopBrowseGrid = document.getElementById("workshopBrowseGrid");
   var workshopSearchInput = document.getElementById("workshopSearchInput");
@@ -300,6 +302,7 @@
     var ver =
       getExternal() && getExternal().getVersion && getExternal().getVersion();
     if (ver) {
+      _currentRunningVersion = "v" + ver;
       var vd = document.getElementById("versionDisplay");
       if (vd) vd.textContent = "v" + ver;
       var sv = document.getElementById("settingsVersion");
@@ -3569,16 +3572,23 @@
     } catch (e) {}
   }
 
-  function addVersionOption(value, label) {
+  function addVersionOption(value, label, prepend) {
     if (!versionOptions) return;
     var div = document.createElement("div");
     div.className = "version-selector-option";
     div.setAttribute("data-value", value);
-    div.textContent = label;
+    div.textContent =
+      _currentRunningVersion && value === _currentRunningVersion
+        ? label + " (installed)"
+        : label;
     div.onclick = function () {
       selectVersion(value, label);
     };
-    versionOptions.appendChild(div);
+    if (prepend && versionOptions.firstChild) {
+      versionOptions.insertBefore(div, versionOptions.firstChild);
+    } else {
+      versionOptions.appendChild(div);
+    }
   }
 
   if (verDropDisplay) {
@@ -3592,11 +3602,17 @@
     };
   }
 
+  function getLatestLabel() {
+    return _latestVersionTag
+      ? _latestVersionTag + " (Latest)"
+      : "Latest (Auto-update)";
+  }
+
   if (versionOptions) {
     var defaultOpt = versionOptions.querySelector(".version-selector-option");
     if (defaultOpt) {
       defaultOpt.onclick = function () {
-        selectVersion("latest", "Latest (Auto-update)");
+        selectVersion("latest", getLatestLabel());
       };
     }
   }
@@ -3626,7 +3642,7 @@
     if (sv) {
       _selectedVersion = versionTagFromStored(sv);
 
-      var initialLabel = "Latest (Auto-update)";
+      var initialLabel = getLatestLabel();
       if (_selectedVersion === "beta") initialLabel = "Beta (Experimental)";
       else if (_selectedVersion !== "latest") initialLabel = _selectedVersion;
       selectVersion(_selectedVersion, initialLabel);
@@ -3645,6 +3661,15 @@
       if (xhr.status === 200) {
         try {
           var releases = JSON.parse(xhr.responseText);
+          if (releases && Array.isArray(releases) && releases.length) {
+            _latestVersionTag = releases[0].tag_name;
+            var defaultOptEl = versionOptions.querySelector(
+              '.version-selector-option[data-value="latest"]'
+            );
+            if (defaultOptEl) {
+              defaultOptEl.textContent = getLatestLabel();
+            }
+          }
           if (releases && Array.isArray(releases)) {
             for (var i = 0; i < releases.length; i++) {
               var rel = releases[i];
@@ -3667,7 +3692,7 @@
             }
           }
           // After loading all versions, ensure UI reflects saved selection
-          var label = "Latest (Auto-update)";
+          var label = getLatestLabel();
           if (_selectedVersion === "beta") label = "Beta (Experimental)";
           else if (_selectedVersion !== "latest") label = _selectedVersion;
           selectVersion(_selectedVersion, label);
@@ -3681,14 +3706,15 @@
     xhr.send();
   }
 
-  fetchReleases();
-
-  // Beta build
+  // Beta build - added first and prepended so it stays pinned at the top
+  // of the list regardless of when the releases fetch below resolves.
   _versionsData["beta"] = {
     url: "https://r2.ezz.lol/boiii/beta/boiii.exe",
     name: "boiii-beta.exe",
   };
-  addVersionOption("beta", "Beta (Experimental)");
+  addVersionOption("beta", "Beta (Experimental)", true);
+
+  fetchReleases();
 
   var creditsPopup = document.getElementById("creditsPopup");
   var versionDisplay = document.getElementById("versionDisplay");

--- a/src/client/launcher/launcher.cpp
+++ b/src/client/launcher/launcher.cpp
@@ -1171,7 +1171,6 @@ bool handle_version_launch(const std::string &exe_name,
     }
   }
 
-  utils::properties::store("selectedVersion", exe_name);
   relaunch_exe_with_launch_options(exe_name, options);
   return true;
 }


### PR DESCRIPTION
## Problem Statement

Follow up to #265, requested separately rather than folded into it since it's UI polish on top of that fix rather than another bug in the same mechanism. This is stacked on #265's branch since it touches the exact same functions, so this diff will include #265's commits until that one merges.

Three things about the version dropdown:

1. Nothing indicates which entry in the list is actually the version currently running, so you can't tell at a glance while browsing.
2. "Latest (Auto-update)" reads as an unrelated option from the concrete version it resolves to, since that same version already shows up as its own entry in the list right below it.
3. Beta's position in the list depends on whether the releases fetch resolves before or after the beta entry gets appended, so it isn't reliably anywhere in particular.

## Solution

Entries in the dropdown now get an "(installed)" suffix if their tag matches the currently running version (read via the existing getVersion bridge call, same one already used for the nav bar version display).

"Latest (Auto-update)" becomes e.g. "v1.2.0 (Latest)" once the releases fetch resolves, using the newest entry in the GitHub releases response, both for the dropdown button label and the list entry's own text.

Beta is now added before the releases fetch starts and inserted at the front of the list instead of appended, so it's always first regardless of how long the fetch takes.

## Testing

Checked the file with node --check for syntax errors. Haven't clicked through the actual UI yet.

Relates to #265.