### PR TITLE
Guard VM_OP_Script*Call_Handler opcode handlers against invalid function_frame pointer

### DIFF
--- a/src/client/component/vm.cpp
+++ b/src/client/component/vm.cpp
@@ -1,0 +1,97 @@
+#include <std_include.hpp>
+#include <loader/component_loader.hpp>
+
+#include <game/game.hpp>
+#include <game/utils.hpp>
+#include <utils/hook.hpp>
+
+namespace vm {
+inline bool vm_op_call_state_valid(game::scr::scriptInstance_t inst) {
+  const auto *frame = game::scr::vm::gScrVmPub->instance[inst].function_frame;
+  return game::nonnull(frame) && game::nonnull(frame->fs.startTop) &&
+        game::nonnull(frame->fs.top);
+}
+
+void log_invalid_vm_state(const char *handler_name) {
+  fprintf(stderr, "[vm] skipped %s: invalid function_frame state\n",
+         handler_name);
+  game::com::Com_Printf(
+      0, game::consoleLabel_e::DEFAULT,
+      "[vm] skipped %s: invalid function_frame state\n", handler_name);
+}
+
+utils::hook::detour VM_OP_ScriptFunctionCall_Handler_hook;
+void VM_OP_ScriptFunctionCall_Handler_Safe(
+    game::scr::scriptInstance_t inst, game::scr::vm::function_stack_t *fs,
+    volatile game::scr::vm::ScrVmContext_t *vmc, bool *terminate) {
+  if (vm_op_call_state_valid(inst)) {
+    VM_OP_ScriptFunctionCall_Handler_hook.invoke(inst, fs, vmc, terminate);
+  } else {
+    log_invalid_vm_state("VM_OP_ScriptFunctionCall_Handler");
+  }
+}
+
+utils::hook::detour VM_OP_ScriptMethodCall_Handler_hook;
+void VM_OP_ScriptMethodCall_Handler_Safe(
+    game::scr::scriptInstance_t inst, game::scr::vm::function_stack_t *fs,
+    volatile game::scr::vm::ScrVmContext_t *vmc, bool *terminate) {
+  if (vm_op_call_state_valid(inst)) {
+    VM_OP_ScriptMethodCall_Handler_hook.invoke(inst, fs, vmc, terminate);
+  } else {
+    log_invalid_vm_state("VM_OP_ScriptMethodCall_Handler");
+  }
+}
+
+utils::hook::detour VM_OP_ScriptMethodThreadCall_Handler_hook;
+void VM_OP_ScriptMethodThreadCall_Handler_Safe(
+    game::scr::scriptInstance_t inst, game::scr::vm::function_stack_t *fs,
+    volatile game::scr::vm::ScrVmContext_t *vmc, bool *terminate) {
+  if (vm_op_call_state_valid(inst)) {
+    VM_OP_ScriptMethodThreadCall_Handler_hook.invoke(inst, fs, vmc, terminate);
+  } else {
+    log_invalid_vm_state("VM_OP_ScriptMethodThreadCall_Handler");
+  }
+}
+
+utils::hook::detour VM_OP_ScriptThreadCall_Handler_hook;
+void VM_OP_ScriptThreadCall_Handler_Safe(
+    game::scr::scriptInstance_t inst, game::scr::vm::function_stack_t *fs,
+    volatile game::scr::vm::ScrVmContext_t *vmc, bool *terminate) {
+  if (vm_op_call_state_valid(inst)) {
+    VM_OP_ScriptThreadCall_Handler_hook.invoke(inst, fs, vmc, terminate);
+  } else {
+    log_invalid_vm_state("VM_OP_ScriptThreadCall_Handler");
+  }
+}
+
+struct component final : generic_component {
+  void post_unpack() override {
+    /*
+       Fix memory access exception in the VM_OP_Script*Call_Handler opcode
+       handlers, observed crashing during zombies round transitions (e.g.
+       Der Eisendrache). Root cause is difficult to narrow down due to a
+       callstack obfuscated by arxan: the embedded-call-count guard already
+       present in these handlers is intact and unmodified, but the
+       function_frame pointer they index into is sometimes invalid despite
+       the guard passing. We circumvent this by verifying function_frame and
+       its startTop/top fields are valid before letting the original handler
+       run, logging and skipping the call instead of invoking it when they
+       are not.
+    */
+    VM_OP_ScriptFunctionCall_Handler_hook.create(
+        game::scr::vm::op::VM_OP_ScriptFunctionCall_Handler.get(),
+        VM_OP_ScriptFunctionCall_Handler_Safe);
+    VM_OP_ScriptMethodCall_Handler_hook.create(
+        game::scr::vm::op::VM_OP_ScriptMethodCall_Handler.get(),
+        VM_OP_ScriptMethodCall_Handler_Safe);
+    VM_OP_ScriptMethodThreadCall_Handler_hook.create(
+        game::scr::vm::op::VM_OP_ScriptMethodThreadCall_Handler.get(),
+        VM_OP_ScriptMethodThreadCall_Handler_Safe);
+    VM_OP_ScriptThreadCall_Handler_hook.create(
+        game::scr::vm::op::VM_OP_ScriptThreadCall_Handler.get(),
+        VM_OP_ScriptThreadCall_Handler_Safe);
+  }
+};
+} // namespace vm
+
+REGISTER_COMPONENT(vm::component)


### PR DESCRIPTION
## Problem Statement

See #260 and #261. Game crashes with EXCEPTION_ACCESS_VIOLATION during zombies round transitions on Der Eisendrache, both right at round 1 into round 2 and later into a run. This is the same crash #263 addressed, opened fresh against beta since the version of it that landed there got reverted for causing a black screen on launch (valid_module_ptr rejects function_frame since it isn't module-allocated, so every call through these handlers was getting skipped, not just the corrupted ones).

## Solution

The four VM_OP_Script*Call_Handler opcode handlers (Function, Method, MethodThread, Thread) already guard against too many embedded function calls with a count check, and that check is intact and passes. The crash happens right after, dereferencing function_frame, which is sometimes invalid despite the guard passing.

Hooked the four handlers and check function_frame and its fs.startTop/fs.top fields with nonnull before letting the original handler run, logging and skipping the call instead of invoking it when any of them aren't. Tried a few things for this check before landing on nonnull:

- readable_ptr catches more (actually checks if the memory is committed and readable), but tanks FPS on Windows specifically, confirmed by testing.
- valid_module_ptr is what caused the black screen mentioned above, since function_frame isn't static module data.
- A check for the specific corrupted pointer shape seen in the crash dumps (low 32 bits zeroed) didn't stop the crash on retest, same address and same corrupted value reproduced identically across two separate sessions, which points at the pointer going bad partway through one of these handler's own execution rather than being wrong at the moment the handler is entered. A check at entry can't catch that regardless of how strict it is.

Given that, nonnull won't catch every possible corrupted pointer, but it's the cheap option that doesn't reject legitimate calls, and is what's here now.

This is a mitigation around the four handlers that dereference function_frame, not a fix for whatever leaves it invalid or lets it walk out of bounds in the first place.

## Testing

Reproduced the crash and confirmed it's fixed through several zombies rounds with no crash. Also confirmed the valid_module_ptr version's black screen on launch and that nonnull doesn't have that problem.

Relates to #260 and #261.